### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Challenge Hunt keeps you updated with all active and upcoming coding competition
 ## Download
 * [Chrome Extension](https://bit.ly/challengehunt)
 
-##Contribution
+## Contribution
 For contributing to Challenge Hunt refer to [How to contribute?](CONTRIBUTING.md).
 
-##Bugs/Suggestions
+## Bugs/Suggestions
 If you have any bugs or suggestions, we would love to hear them from you. Add them [here](https://github.com/ChallengeHunt/challengehunt/issues/new).
 
 ## More Screenshots
@@ -19,15 +19,15 @@ If you have any bugs or suggestions, we would love to hear them from you. Add th
 ![](http://i.imgur.com/kSK4xNV.png?1)
 ![](http://i.imgur.com/nHXgRQP.png?1)
 
-##Website:
+## Website:
 [Challenge Hunt home page](http://challengehunt.github.io)
 
-###Made By:
+### Made By:
 
 * [Archit Verma](https://github.com/architv)
 * [Sukhmeet Singh](https://github.com/sukhmeet032795)
 * [Chirrag Nangia](https://github.com/chirrag03)
 
-###License:
+### License:
 
 Open sourced under [MIT License](https://github.com/ChallengeHunt/challengehunt/blob/master/LICENSE.md).


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
